### PR TITLE
Update command for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,17 @@ cd Birthday
 
 && 
 
+If you use *Mac/Linux* use
+
 ```
 python -m SimpleHTTPServer --port  8081
 ```
 
+If you use *Windows* use 
+
+```
+python -m http.server 8081
+```
 visit http://localhost:8081 in your browser.
 
 ## If you have nodejs installed

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ cd Birthday
 
 && 
 
-If you use *Mac/Linux* use
+If yous OS is *Mac/Linux* use
 
 ```
 python -m SimpleHTTPServer --port  8081
 ```
 
-If you use *Windows* use 
+If yous OS is *Windows* use 
 
 ```
 python -m http.server 8081


### PR DESCRIPTION
For Windows if I use `python -m SimpleHTTPServer 8000` it shows the error `python.exe: No module named SimpleHTTPServer`. In Windows has been this module renamed in Python and we need to use this command line instead: 

` python -m http.server 8000 ` 

![image](https://user-images.githubusercontent.com/14244685/82317546-3fcfb880-99f0-11ea-9e9c-fe6d3b1bf20e.png)
